### PR TITLE
Direct link to sponsor-big-development section

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -91,7 +91,7 @@
       <p class="faq-answer">Certainly! Donate money, crypto or a tractor :) See here how you can <a href="support.html">support us</a>
       </p>
       <h1 class="faq-guestion">Can I Sponsor?</h1>
-      <p class="faq-answer">Yep, You can actually <a href="support.html">sponsor</a> direct BIG development. Get your name on a building. Have a look on the support page or send an email</p>
+      <p class="faq-answer">Yep, You can actually <a href="support.html#sponsor-big-development">sponsor</a> direct BIG development. Get your name on a building. Have a look on the support page or send an email</p>
       <h1 class="faq-guestion">Can I get in touch?</h1>
       <p class="faq-answer">Yeh sure. hello@projectkamp.com is the best way</p>
     </div>

--- a/support.html
+++ b/support.html
@@ -429,6 +429,7 @@
         </nav>
       </div>
     </div>
+    <span id="sponsor-big-development"></span>
     <div class="share-to-support wf-section">
       <div class="dev-list">
         <h1 class="heading-12 big">Sponsor <strong class="big">big</strong> development </h1>


### PR DESCRIPTION
- A fragment identifier was added to the sponsor link in the FAQ page to modify the link behavior. Now, when the link is clicked, users will be taken directly to the sponsor-big-development section of the support page, eliminating the need to scroll down