### PR TITLE
Add Youtube hyperlink to season headers & neat season 3 page

### DIFF
--- a/css/project-kamp.css
+++ b/css/project-kamp.css
@@ -1663,6 +1663,15 @@ a {
   font-size: 48px;
 }
 
+.seasonheader a {
+  color: #8ab580;
+  text-decoration: none;
+}
+
+.seasonheader a:hover {
+  color: #5c8356;
+}
+
 .slide {
   overflow: visible;
 }
@@ -2147,7 +2156,7 @@ a {
 .div-block-17 {
   justify-content: center;
   align-items: flex-start;
-  margin-bottom: 900px;
+  margin-bottom: 225px;
   display: flex;
 }
 

--- a/season-1.html
+++ b/season-1.html
@@ -195,7 +195,7 @@
       </div>
     </div>
     <div class="season">
-      <h1 class="seasonheader center">Watch all episodes season #1</h1>
+      <h1 class="seasonheader center"><a target="_blank" href="https://www.youtube.com/playlist?list=PLB9itIy7Yj62A0lcU4c0Ep1QxGbN3GIHi">Watch all episodes season #1</a></h1>
       <div>
         <div class="w-layout-grid grid">
           <a href="https://youtu.be/_pQNSjr64zI" target="_blank" class="thumb-info w-inline-block"><img sizes="(max-width: 479px) 92vw, (max-width: 767px) 95vw, (max-width: 991px) 96vw, 100vw" srcset="images/40-We-made-a-roof-from-RECYCLED-PLASTIC-sheets-p-500.jpeg 500w, images/40-We-made-a-roof-from-RECYCLED-PLASTIC-sheets-p-800.jpeg 800w, images/40-We-made-a-roof-from-RECYCLED-PLASTIC-sheets.jpg 1280w" src="images/40-We-made-a-roof-from-RECYCLED-PLASTIC-sheets.jpg" loading="lazy" alt="" class="grid-image">

--- a/season-2.html
+++ b/season-2.html
@@ -255,7 +255,7 @@
       </div>
     </div>
     <div class="season">
-      <h1 class="seasonheader center">Watch all episodes season #2</h1>
+      <h1 class="seasonheader center"><a target="_blank" href="https://www.youtube.com/playlist?list=PLB9itIy7Yj63FCZGyWsYwR_XA3Y0OQ6H3">Watch all episodes season #2</a></h1>
       <div class="html-embed-3 w-embed w-iframe"><iframe width="800" height="500" src="https://www.youtube.com/embed/ZHKph8nMC3A" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen=""></iframe></div>
       <div>
         <div class="w-layout-grid grid hidden">

--- a/season-3.html
+++ b/season-3.html
@@ -65,19 +65,15 @@
     <div class="title">
       <h1 class="heading-13">Season #3</h1>
       <h1 class="heading-13 sub">2023 - Ongoing</h1>
-      <div class="video">
-        <div class="div-block-16"></div>
-        <div style="padding-top:56.17021276595745%" class="w-embed-youtubevideo videoborder"><iframe src="https://www.youtube.com/embed/aJjxyN0J2BI?rel=0&amp;controls=1&amp;autoplay=0&amp;mute=0&amp;start=0" frameborder="0" style="position:absolute;left:0;top:0;width:100%;height:100%;pointer-events:auto" allow="autoplay; encrypted-media" allowfullscreen="" title="Everything we will do this year"></iframe></div>
-      </div>
-    </div>
-    <div class="div-block-17">
-      <h1 class="message">This is everything we want to do this Season. Support us on Patreon or come and join us here to help. <br>
-        <a href="#">click here :)</a>
-      </h1>
     </div>
     <div class="video">
       <div class="div-block-16"></div>
-      <div style="padding-top:56.17021276595745%" class="w-embed-youtubevideo videoborder"><iframe src="https://www.youtube.com/embed/ZHKph8nMC3A?rel=0&amp;controls=1&amp;autoplay=0&amp;mute=0&amp;start=0" frameborder="0" style="position:absolute;left:0;top:0;width:100%;height:100%;pointer-events:auto" allow="autoplay; encrypted-media" allowfullscreen="" title="#41 START NEW SEASON! Here is everything we will do coming year"></iframe></div>
+      <div style="padding-top:56.17021276595745%" class="w-embed-youtubevideo videoborder"><iframe src="https://www.youtube.com/embed/aJjxyN0J2BI?rel=0&amp;controls=1&amp;autoplay=0&amp;mute=0&amp;start=0" frameborder="0" style="position:absolute;left:0;top:0;width:100%;height:100%;pointer-events:auto" allow="autoplay; encrypted-media" allowfullscreen="" title="Everything we will do this year"></iframe></div>
+    </div>
+    <div class="div-block-17">
+      <h1 class="message">This is everything we want to do this Season. Support us on Patreon or come and join us here to help. <br>
+        <a href="https://projectkamp.com/support.html">click here :)</a>
+      </h1>
     </div>
   </div>
   <div class="one-army-footer wf-section">


### PR DESCRIPTION
- season 1 & season 2 page: A hyperlink was added to the 'Watch all episodes' header at the bottom. The update includes a clickable link that directs users to the respective season YouTube playlist. The link opens in a new tab, allowing them to easily browse and watch all episodes without any extra navigation steps.

- season 3 page: The divison holding the new season video was taken outside the page title division incorporating the consistent spacing found between the page title and video on both season 1 and season 2 pages.

- season 3 page: The video from the beginning of season 2 was removed

- Two CSS selectors for the seasonheader class were added to the project-kamp.css file. This selector provide the style when hovering the header.

- Margin bottom for the div-block-17 class was reduced from 900px to 225px. This eliminates the huge gap that was left when removing the season 2 video from the season 3 page.